### PR TITLE
update installation scripts to handle new build proceedure

### DIFF
--- a/files/playbooks/prep.yml
+++ b/files/playbooks/prep.yml
@@ -178,17 +178,6 @@
         repo: "git://github.com/osumo/osumo-project.git"
         version: "{{ revision }}"
 
-    - name: plugin | osumo | symlink
-      file:
-        src: /opt/osumo-project/osumo
-        dest: /opt/osumo-project/girder/plugins/osumo
-        state: link
-
-    - name: scripts | copy
-      copy:
-        src: ../scripts/girder-post-install.py
-        dest: /opt/osumo-project/girder-post-install.py
-
     - name: resonant | configure
       template:
         src: "../templates/{{ item.src }}.j2"
@@ -202,6 +191,11 @@
           dest: girder.bash
         - src: worker.bash
           dest: worker.bash
+
+    - name: scripts | copy
+      copy:
+        src: ../scripts/girder-post-install.py
+        dest: /opt/osumo-project/girder-post-install.py
 
 - hosts: worker
   user: ubuntu

--- a/files/scripts/girder-post-install.py
+++ b/files/scripts/girder-post-install.py
@@ -95,6 +95,10 @@ args = parser.parse_args()
 client = GirderClient(host=args.host, port=args.port)
 
 user, password = args.admin.split(":", 1)
+
+if find_user('girder'):
+    client.authenticate('girder', 'girder')
+
 ensure_user(client,
             login=user,
             password=password,
@@ -126,7 +130,6 @@ client.put(
     'system/plugins',
     parameters=dict(plugins=json.dumps(['jobs', 'worker', 'osumo']))
 )
-
 client.put('system/restart')
 
 sleep(30)
@@ -134,7 +137,11 @@ sleep(30)
 client.put('system/setting',
            parameters=dict(list=json.dumps([
                dict(key='worker.broker', value=args.broker),
-               dict(key='worker.backend', value=args.broker)])))
+               dict(key='worker.backend', value=args.broker),
+               dict(key='core.route_table', value=dict(
+                                               core_girder="/girder",
+                                               core_static_root="/static",
+                                               osumo="/"))])))
 
 client.put('system/restart')
 

--- a/files/templates/girder.bash.j2
+++ b/files/templates/girder.bash.j2
@@ -16,9 +16,10 @@ source /opt/nvm/nvm.sh
 nvm use v6
 
 pushd girder
-npm install
-python setup.py develop
-python -m girder &
+pip install -e '.[plugins]'
+girder-install plugin ../osumo
+girder-install web
+girder-server &
 popd
 
 if [ '!' -d "$initialization_path" ] ; then
@@ -37,6 +38,11 @@ if [ '!' -d "$initialization_path" ] ; then
         --aws-key-id "{{ aws_access_key_id }}"                                       \
         --aws-secret-key "{{ aws_secret_access_key }}"
 fi
+
+pushd girder
+girder-install web
+girder-install web --plugins osumo --plugin-prefix index
+popd
 
 wait
 

--- a/files/templates/worker.bash.j2
+++ b/files/templates/worker.bash.j2
@@ -13,7 +13,8 @@ source /opt/nvm/nvm.sh
 nvm use v6
 
 pushd girder_worker
-python -m girder_worker &
+pip install -e '.'
+girder-worker &
 
 if [ '!' -d "$initialization_path" ] ; then
     rm -rf "worker_init"

--- a/files/templates/worker.local.cfg.j2
+++ b/files/templates/worker.local.cfg.j2
@@ -1,4 +1,5 @@
 [celery]
+app_main=girder_worker
 broker=amqp://guest@{{ hostvars[groups["queue"][0]]["aws_private_ip"] }}/
 
 [girder_worker]


### PR DESCRIPTION
Makes a number of small changes to the Ansible/Bash/Python scripts in sumobot so that it handles the new way that plugins are installed and built in Girder 2.0.

Also, ensures that OSUMO is served on the root of the web server, and girder on `/girder`.